### PR TITLE
drop usage of VCPKG_ROOT

### DIFF
--- a/.github/workflows/hosted-pure-workflow.yml
+++ b/.github/workflows/hosted-pure-workflow.yml
@@ -33,7 +33,10 @@ jobs:
             triplet: x64-osx
     env:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      # Not using "VCPKG_ROOT" because a variable with the same name is defined in the VS's
+      # Developer Command Prompt environment in VS 2022 17.6, which would override this one 
+      # if it had the same name.
+      _VCPKG_: ${{ github.workspace }}/vcpkg
       # Tells vcpkg where binary packages are stored.
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
       # Let's use GitHub Action cache as storage for the vcpkg Binary Caching feature.
@@ -67,11 +70,11 @@ jobs:
           # built package archives (aka binary cache) which are located by VCPKG_DEFAULT_BINARY_CACHE env var.
           # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
           path: |
-            ${{ env.VCPKG_ROOT }}
-            !${{ env.VCPKG_ROOT }}/buildtrees
-            !${{ env.VCPKG_ROOT }}/packages
-            !${{ env.VCPKG_ROOT }}/downloads
-            !${{ env.VCPKG_ROOT }}/installed
+            ${{ env._VCPKG_ }}
+            !${{ env._VCPKG_ }}/buildtrees
+            !${{ env._VCPKG_ }}/packages
+            !${{ env._VCPKG_ }}/downloads
+            !${{ env._VCPKG_ }}/installed
           # The key is composed in a way that it gets properly invalidated whenever a different version of vcpkg is being used.
           key: |
             ${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,11 +15,8 @@
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": {
                     "type": "FILEPATH",
-                    "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                    "value": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
                 }
-            },
-            "environment": {
-                "VCPKG_ROOT": "./vcpkg"
             }
         }
     ],
@@ -39,18 +36,18 @@
             "configuration": "Release"
         },
         {
-          "name": "ninja-vcpkg",
-          "configurePreset": "ninja-multi-vcpkg",
-          "displayName": "Build",
-          "description": "Build with Ninja/vcpkg"
-      }
+            "name": "ninja-vcpkg",
+            "configurePreset": "ninja-multi-vcpkg",
+            "displayName": "Build",
+            "description": "Build with Ninja/vcpkg"
+        }
     ],
     "testPresets": [
         {
             "name": "test-ninja-vcpkg",
             "configurePreset": "ninja-multi-vcpkg",
             "hidden": true
-        },        
+        },
         {
             "name": "test-debug",
             "description": "Test (Debug)",
@@ -61,13 +58,13 @@
             ]
         },
         {
-          "name": "test-release",
-          "description": "Test (Release)",
-          "displayName": "Test (Release)",
-          "configuration": "Release",
-          "inherits": [
-              "test-ninja-vcpkg"
-          ]
-      }
-  ]
+            "name": "test-release",
+            "description": "Test (Release)",
+            "displayName": "Test (Release)",
+            "configuration": "Release",
+            "inherits": [
+                "test-ninja-vcpkg"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
VCPKG_ROOT is not needed to be used anywhere. Since the vcpkg repository is in a submodule, the path relative to the root of the Git repository is well known, and it could be used in the CMakePresets.json.