### PR TITLE
Prefer using sourceDir variable instead of current working folder

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,7 @@
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": {
                     "type": "FILEPATH",
-                    "value": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
+                    "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
                 }
             }
         }


### PR DESCRIPTION
I am now working on changing how we use vcpkg.json in https://github.com/OPM/ResInsight
Using `sourceDir` variable fixed issues in my ongoing work.