### PR TITLE
Add CMakePreset JSON Schema

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
     "version": 3,
     "cmakeMinimumRequired": {
         "major": 3,


### PR DESCRIPTION
Most IDEs, and text editors support json schema these days, e.g., VS Code; and I thought adding the schema might help people who are starting to experiment with the CMake preset as they base their projects on this template.